### PR TITLE
Add backend support for Date Night Idea sharing & matching

### DIFF
--- a/app/api/date-ideas/[id]/like/route.ts
+++ b/app/api/date-ideas/[id]/like/route.ts
@@ -1,0 +1,51 @@
+import prisma from "@/lib/prisma";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/auth";
+
+interface Params {
+  params: {
+    id: string;
+  };
+}
+
+// POST /api/date-ideas/[id]/like - toggle like for current user
+export async function POST(request: Request, { params }: Params) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const ideaId = parseInt(params.id, 10);
+  if (isNaN(ideaId)) {
+    return NextResponse.json({ error: "Invalid idea id" }, { status: 400 });
+  }
+
+  // Check if like already exists
+  const existingLike = await prisma.ideaLike.findUnique({
+    where: {
+      userId_ideaId: {
+        userId: session.user.id,
+        ideaId,
+      },
+    },
+  });
+
+  if (existingLike) {
+    // Remove like (unlike)
+    await prisma.ideaLike.delete({
+      where: { id: existingLike.id },
+    });
+    return NextResponse.json({ liked: false });
+  }
+
+  // Add like
+  await prisma.ideaLike.create({
+    data: {
+      userId: session.user.id,
+      ideaId,
+    },
+  });
+  return NextResponse.json({ liked: true });
+}
+

--- a/app/api/date-ideas/matches/route.ts
+++ b/app/api/date-ideas/matches/route.ts
@@ -1,0 +1,49 @@
+import prisma from "@/lib/prisma";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/auth";
+
+// GET /api/date-ideas/matches - ideas liked by current user AND at least one other user
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // First, find idea ids liked by current user
+  const likedIdeaIds = await prisma.ideaLike.findMany({
+    where: { userId: session.user.id },
+    select: { ideaId: true },
+  });
+
+  const ids = likedIdeaIds.map((l) => l.ideaId);
+  if (ids.length === 0) return NextResponse.json({ matches: [] });
+
+  // Fetch ideas where other users also liked
+  const matches = await prisma.dateIdea.findMany({
+    where: {
+      id: { in: ids },
+      likes: {
+        some: {
+          userId: { not: session.user.id },
+        },
+      },
+    },
+    include: {
+      _count: { select: { likes: true } },
+      createdBy: { select: { name: true } },
+    },
+  });
+
+  const formatted = matches.map((idea) => ({
+    id: idea.id,
+    title: idea.title,
+    description: idea.description,
+    createdAt: idea.createdAt,
+    likeCount: (idea as any)._count.likes as number,
+    createdByName: idea.createdBy?.name ?? "Anonymous",
+  }));
+
+  return NextResponse.json({ matches: formatted });
+}
+

--- a/app/api/date-ideas/route.ts
+++ b/app/api/date-ideas/route.ts
@@ -1,0 +1,69 @@
+import prisma from "@/lib/prisma";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/auth";
+
+// GET /api/date-ideas - list date ideas with pagination
+export async function GET(request: Request) {
+  const session = await getServerSession(authOptions);
+  const url = new URL(request.url);
+  const page = parseInt(url.searchParams.get("page") || "1", 10);
+  const ideasPerPage = 8;
+  const offset = (page - 1) * ideasPerPage;
+
+  // Fetch paginated ideas along with like count and whether the current user liked the idea
+  const ideas = await prisma.dateIdea.findMany({
+    skip: offset,
+    take: ideasPerPage,
+    orderBy: { createdAt: "desc" },
+    include: {
+      _count: { select: { likes: true } },
+      likes: session?.user ? { where: { userId: session.user.id }, select: { id: true } } : false,
+      createdBy: { select: { name: true } },
+    },
+  });
+
+  const formattedIdeas = ideas.map((idea) => ({
+    id: idea.id,
+    title: idea.title,
+    description: idea.description,
+    image: idea.image,
+    createdAt: idea.createdAt,
+    createdByName: idea.createdBy?.name ?? "Anonymous",
+    likeCount: (idea as any)._count.likes as number,
+    likedByMe: idea.likes && idea.likes.length > 0,
+  }));
+
+  const totalIdeas = await prisma.dateIdea.count();
+  const totalPages = Math.ceil(totalIdeas / ideasPerPage);
+
+  return NextResponse.json({ ideas: formattedIdeas, totalPages });
+}
+
+// POST /api/date-ideas - create a new date idea
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { title, description, image } = body;
+
+  if (!title || typeof title !== "string") {
+    return NextResponse.json({ error: "Title is required" }, { status: 400 });
+  }
+
+  const newIdea = await prisma.dateIdea.create({
+    data: {
+      title,
+      description: description ?? null,
+      image: image ?? null,
+      createdById: session.user.id,
+    },
+  });
+
+  return NextResponse.json(newIdea, { status: 201 });
+}
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,8 @@ model User {
   email    String  @unique
   password String
   posts    Post[]
+  dateIdeas DateIdea[] @relation("UserDateIdeas")
+  ideaLikes IdeaLike[]
 }
 
 model Post {
@@ -31,3 +33,27 @@ model Post {
   authorId  String?
   author    User?    @relation(fields: [authorId], references: [id])
 }
+
+/// -------------- New for Date Night feature --------------
+model DateIdea {
+  id          Int        @id @default(autoincrement())
+  createdAt   DateTime   @default(now())
+  title       String
+  description String?
+  image       String?
+  createdById String
+  createdBy   User       @relation(name: "UserDateIdeas", fields: [createdById], references: [id])
+  likes       IdeaLike[]
+}
+
+model IdeaLike {
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now())
+  userId    String
+  ideaId    Int
+  user      User      @relation(fields: [userId], references: [id])
+  idea      DateIdea  @relation(fields: [ideaId], references: [id])
+
+  @@unique([userId, ideaId])
+}
+


### PR DESCRIPTION
### ✨ What’s new
1. **Prisma models** – `DateIdea` and `IdeaLike` were added to persist date-night ideas and the likes that power matching.
2. **API routes**
   • `GET /api/date-ideas` – paginated list that tells the caller whether the signed-in user has liked each idea.
   • `POST /api/date-ideas` – authenticated endpoint to create a new idea.
   • `POST /api/date-ideas/[id]/like` – toggles a like for the signed-in user (acts as a swipe).
   • `GET /api/date-ideas/matches` – returns ideas liked by the current user **and** at least one other user (the “match”).

These endpoints give the front-end everything needed for a fun Tinder-style experience: load ideas, swipe (like/unlike) and see mutual matches.

> NOTE: run `npx prisma migrate dev --name date-ideas` to create the new tables locally and `npx prisma generate` afterwards if necessary.

No UI changes were included to keep the PR tight and focused on the data layer. The front-end can now consume these endpoints to build a playful carousel or swipe component.

Closes #3